### PR TITLE
fix(remix-template): update config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Deploy and serve your [Remix](https://remix.run/) website from Fastly's blazing-fast [Compute@Edge](https://developer.fastly.com/learning/compute/).
 
-> NOTE: This cannot currently be used as is, as it relies on a `serverBuildTarget` value that is not supported by Remix at this time.
-> A pull request has been submitted to Remix to support this value, and it will be usable once https://github.com/remix-run/remix/pull/4860 lands.
-
 ## Remix
 
 Remix is a popular JavaScript-based full stack web framework that is designed to allow the developer to focus on the

--- a/packages/remix-template/remix.config.js
+++ b/packages/remix-template/remix.config.js
@@ -1,9 +1,14 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  serverBuildTarget: "fastly-compute-js",
-  devServerBroadcastDelay: 10000, // Adjust this if this is too short
+  devServerBroadcastDelay: 1000,
   ignoredRouteFiles: ["**/.*"],
-  // The following are the default values, feel free to uncomment and make adjustments as necessary
+  server: "./server.js",
+  serverConditions: ["worker"],
+  serverDependenciesToBundle: "all",
+  serverMainFields: ["browser", "module", "main"],
+  serverMinify: true,
+  serverModuleFormat: "esm",
+  serverPlatform: "neutral",
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",


### PR DESCRIPTION
Closing this as https://github.com/remix-run/remix/pull/4841 is now merged

Once that's released, the `fastly` template can use these new config options.