### PR TITLE
Updated start page created out of the template

### DIFF
--- a/packages/remix-template/app/routes/index.tsx
+++ b/packages/remix-template/app/routes/index.tsx
@@ -1,23 +1,31 @@
+import styles from "~/styles/index.css";
+
+export function links() {
+  return [{ rel: "stylesheet", href: styles }];
+}
+
 export default function Index() {
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
-      <h1>Welcome to Remix</h1>
+      <h1>Congratulations!</h1>
+      <p>
+        You’ve successfully created your <a target="_blank" href="https://remix.run/">Remix</a> project for <a target="_blank" href="https://developer.fastly.com/learning/compute/javascript/">Fastly Compute@Edge</a>.
+      </p>
+      <p>
+        If you already have a Remix application that you'd like to move to Compute@Edge, see
+        our <a target="_blank" href="https://github.com/fastly/remix-compute-js/blob/main/MIGRATING.md">Migration Guide</a>.
+      </p>
+      <p>
+        To learn more about Remix, visit some pages provided by Remix:
+      </p>
       <ul>
         <li>
-          <a
-            target="_blank"
-            href="https://remix.run/tutorials/blog"
-            rel="noreferrer"
-          >
+          <a target="_blank" href="https://remix.run/tutorials/blog" rel="noreferrer">
             15m Quickstart Blog Tutorial
           </a>
         </li>
         <li>
-          <a
-            target="_blank"
-            href="https://remix.run/tutorials/jokes"
-            rel="noreferrer"
-          >
+          <a target="_blank" href="https://remix.run/tutorials/jokes" rel="noreferrer">
             Deep Dive Jokes App Tutorial
           </a>
         </li>
@@ -27,6 +35,18 @@ export default function Index() {
           </a>
         </li>
       </ul>
+      <p>
+        The Compute@Edge Adapter for Remix is provided as part of <a target="_blank" href="https://developer.fastly.com/labs/">Fastly Labs</a>&mdash;where Edge computing meets the cutting edge.
+        Visit Fastly Labs for other exciting projects we provide under this program.
+      </p>
+      <p>
+        Check out Fastly’s <a target="_blank" href="https://www.fastly.com/fast-forward">Fast Forward program</a> to learn more about our broad-reaching
+        programs designed to empower and support open source projects, nonprofit organizations, and developers in their endeavors to build great things
+        with unmatched ease, performance, and security.
+      </p>
+      <p>
+        Enjoy!
+      </p>
     </div>
   );
 }

--- a/packages/remix-template/app/routes/index.tsx
+++ b/packages/remix-template/app/routes/index.tsx
@@ -13,7 +13,7 @@ export default function Index() {
       </p>
       <p>
         If you already have a Remix application that you'd like to move to Compute@Edge, see
-        our <a target="_blank" href="https://github.com/fastly/remix-compute-js/blob/main/MIGRATING.md">Migration Guide</a>.
+        our <a target="_blank" href="https://github.com/fastly/remix-compute-js/blob/main/MIGRATING.md">migration guide</a>.
       </p>
       <p>
         To learn more about Remix, visit some pages provided by Remix:
@@ -36,7 +36,7 @@ export default function Index() {
         </li>
       </ul>
       <p>
-        The Compute@Edge Adapter for Remix is provided as part of <a target="_blank" href="https://developer.fastly.com/labs/">Fastly Labs</a>&mdash;where Edge computing meets the cutting edge.
+        The Compute@Edge Adapter for Remix is provided as part of <a target="_blank" href="https://developer.fastly.com/labs/">Fastly Labs</a>: where edge computing meets the cutting edge.
         Visit Fastly Labs for other exciting projects we provide under this program.
       </p>
       <p>

--- a/packages/remix-template/app/styles/index.css
+++ b/packages/remix-template/app/styles/index.css
@@ -1,0 +1,12 @@
+body {
+    color: #f2f5f7;
+    background-color: #182931;
+}
+
+a {
+    color: #19c6ff;
+}
+
+a:focus, a:hover {
+    color: #80dfff;
+}

--- a/packages/remix-template/app/styles/index.css
+++ b/packages/remix-template/app/styles/index.css
@@ -1,6 +1,7 @@
 body {
     color: #f2f5f7;
     background-color: #182931;
+    margin: auto 2rem;
 }
 
 a {


### PR DESCRIPTION
This PR updates the start page created out of the template.

This is the previous page:

<img width="908" alt="Screenshot 2023-02-20 at 16 51 13" src="https://user-images.githubusercontent.com/1396801/220045058-0d81497b-6696-4edb-8b42-80e45fb50c22.png">

The new start page looks like this:

<img width="908" alt="Screenshot 2023-02-20 at 16 45 09" src="https://user-images.githubusercontent.com/1396801/220043836-9269630e-77e3-4826-89e4-d55d8f260bef.png">

I'm not a graphic artist but I wanted to run the text by the team and get any opinions.