### PR TITLE
fix: error upon resolving "./statics.js"

### DIFF
--- a/packages/remix-server-adapter/README.md
+++ b/packages/remix-server-adapter/README.md
@@ -21,7 +21,7 @@ This function needs to be passed the following parameters:
 ```js
 /// <reference types="@fastly/js-compute" />  
 import { createEventHandler } from '@fastly/remix-server-adapter';
-import { moduleAssets, getServer } from './statics.js';
+import { moduleAssets, getServer } from '../static-publisher/statics.js';
 
 /** @type {import('@remix-run/server-runtime').ServerBuild} */
 const build = moduleAssets.getAsset('/build/index.js').getStaticModule();
@@ -38,7 +38,7 @@ you may use the lower-level `createRequestHandler` and `handleAsset` functions:
 ```js
 /// <reference types="@fastly/js-compute" />  
 import { createRequestHandler, handleAsset } from '@fastly/remix-server-adapter';  
-import { moduleAssets, getServer } from './statics.js';
+import { moduleAssets, getServer } from '../static-publisher/statics.js';
 
 /** @type {import('@remix-run/server-runtime').ServerBuild} */
 const build = moduleAssets.getAsset('/build/index.js').getStaticModule();


### PR DESCRIPTION
This PR fixes the following build error.

```
> js-compute-runtime ./src/index.js ./bin/main.wasm

✘ [ERROR] Could not resolve "./statics.js"

    src/index.js:3:40:
      3 │ import { moduleAssets, getServer } from './statics.js';
        ╵                                         ~~~~~~~~~~~~~~
```